### PR TITLE
Allow for components that are not maps (e.g., Java objects)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ assembling it.
 Initially, this is to allow more concise (and less redundant)
 component create functions.
 
+It is now possible for a component to be an arbitrary Java object, rather
+than a Clojure map.
+Previously, this would result in a runtime exception.
+Optionally, you may extend the `com.stuartsierra.component/Lifecycle` protocol
+onto the Java object.
+
+[Closed Issues](https://github.com/walmartlabs/schematic/milestone/2?closed=1)
+
 # 1.1.0 -- 29 Mar 2018
 
 Many functions exposed only for testing have been excluded from
@@ -14,3 +22,5 @@ documentation. These functions have the ^:no-doc metadata.
 
 The `merged-subconfig` function has been merged into the `merged-config`
 function.
+
+[Closed Issues](https://github.com/walmartlabs/schematic/milestone/1?closed=1)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/schematic "1.1.0"
+(defproject com.walmartlabs/schematic "1.2.0-SNAPSHOT-1"
   :description "A library to aid in assembling Systems for use with Component"
   :url "https://github.com/walmartlabs/schematic"
   :license {:name "Apache Software License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/schematic "1.2.0-SNAPSHOT-1"
+(defproject com.walmartlabs/schematic "1.1.0"
   :description "A library to aid in assembling Systems for use with Component"
   :url "https://github.com/walmartlabs/schematic"
   :license {:name "Apache Software License 2.0"

--- a/src/com/walmartlabs/schematic.clj
+++ b/src/com/walmartlabs/schematic.clj
@@ -76,7 +76,9 @@
       (if (instance? IObj component')
         (-> component'
             ;; Sanity: clear any existing dependencies already present, though
-            ;; it's not clear why they would be there!
+            ;; Such dependencies might exist in the metadata if a plain-Component constructor
+            ;; function is being re-used as a Schematic component init function. 
+            ;; Schematic does not honor any dependency metadata applied by other means. 
             (vary-meta dissoc ::component/dependencies)
             (component/using ref-map))
         component'))))

--- a/src/com/walmartlabs/schematic.clj
+++ b/src/com/walmartlabs/schematic.clj
@@ -64,6 +64,9 @@
    Component metadata. If it is not associative, the original value is returned.
    Any pre-existing ::component/dependencies will be removed. "
   [v]
+  ;; Most everything value in a schematic system is a map defining the component, its dependencies, and its configuration.
+  ;; However, at the top level can be key/value pairs that are read and injected (via :sc/merge) into components,
+  ;; so leave those alone.
   (if (map? v)
     (let [ref-map (ref-map-for-component v)
           init-fn (resolve-init-fn v)

--- a/test/com/walmartlabs/schematic_test.clj
+++ b/test/com/walmartlabs/schematic_test.clj
@@ -365,11 +365,28 @@
 
 (deftest remove-existing-dependency-metadata
   (testing "existing Component dependency metadata is removed"
-    (let [config {:app {:sc/create-fn 'com.walmartlabs.schematic-test/new-component-with-dependency-metadata}}]
+    (let [config {:app {:sc/create-fn `new-component-with-dependency-metadata}}]
       (is (= {:my :app}
              (-> (sc/assemble-system config)
                  (component/start)
                  :app))))))
+
+(def ^:private psuedo-component (Object.))
+
+(def ^:private new-psuedo-component (constantly psuedo-component))
+
+(deftest allows-non-map-from-init-fn
+  ;; An init-fn may return something not a map, but still a component; it might even have
+  ;; the Lifecycle protocol extended on it.
+  (let [config {:comp/psuedo {:sc/create-fn `new-psuedo-component}
+                :app {:sc/refs {:psuedo :comp/psuedo}}}
+        system (-> config
+                   sc/assemble-system
+                   component/start)]
+    (is (= {:psuedo psuedo-component}
+           (:app system)))
+    (is (identical? psuedo-component
+                    (:comp/psuedo system)))))
 
 (deftest test-debug-fn
   (let [config '{:top {:spin :left}


### PR DESCRIPTION
This came up when I was attempting to make a HTTP connection manager a shared component; it felt like it should work (by extending Lifecycle onto the interface the manager implements) BUT got exceptions in schematic related to `vary-meta` on the component.

This fixes that case, checking to see if the component that results from invoking the init-fn is an IObj, and only manipulates its meta-data if so.

As implemented here, dependencies for such a component are quietly ignored (not applied to the component).