### PR TITLE
Use `transitive-dependencies` instead of direct field access

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+Use `com.stuartsierra.dependency/transitive-dependencies` instead of direct Record field access.
+
 # 1.2.0 -- 4 Dec 2018
 
 Added new `com.walmartlabs.schematic.transform` namespace

--- a/src/com/walmartlabs/schematic.clj
+++ b/src/com/walmartlabs/schematic.clj
@@ -287,12 +287,11 @@
 (defn ^:no-doc subconfig-for-components
   "Returns a map of just the given components and their transitive dependencies"
   [system-config component-ids]
-  (let [dep-graph (ref-dependency-graph system-config)]
-    (loop [ref-ids component-ids deps (set component-ids)]
-      (if-let [ref-id (first ref-ids)]
-        (let [new-deps (get-in dep-graph [:dependencies ref-id])]
-          (recur (concat (rest ref-ids) new-deps) (into deps new-deps)))
-        (select-keys system-config deps)))))
+  (let [dep-graph (ref-dependency-graph system-config)
+        target-keys (->> (mapcat (partial dep/transitive-dependencies dep-graph) component-ids)
+                         (into component-ids)
+                         (set))]
+    (select-keys system-config target-keys)))
 
 ;; -------------------------------------------------
 ;; ## Public API


### PR DESCRIPTION
I noticed what I believe to be an issue with AOT compiled classes and this dependency lookup. This really should have been a call to `transitive-dependencies` in the first place, rather than field-level access.