### PR TITLE
Cleanups and better exception reporting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,14 @@
 # Unreleased
 
-Use `com.stuartsierra.dependency/transitive-dependencies` instead of direct Record field access.
+Schematic now uses `com.stuartsierra.dependency/transitive-dependencies` instead of direct record field access.
 
-Schematic no longer clear dependencies that may already exist on a component returned by
-a create function; it will simply add further dependencies.
+Schematic now captures exceptions while creating components, and wraps those exceptions with additional detail
+about the component key and component map, making it much easier to identify where
+the error has taken place.
+
+Schematic now requires Clojure 1.10.1.
+
+[Closed Issues](https://github.com/walmartlabs/schematic/milestone/3?closed=1)
 
 # 1.2.0 -- 4 Dec 2018
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 Use `com.stuartsierra.dependency/transitive-dependencies` instead of direct Record field access.
 
+Schematic no longer clear dependencies that may already exist on a component returned by
+a create function; it will simply add further dependencies.
+
 # 1.2.0 -- 4 Dec 2018
 
 Added new `com.walmartlabs.schematic.transform` namespace

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Schematic now captures exceptions while creating components, and wraps those exc
 about the component key and component map, making it much easier to identify where
 the error has taken place.
 
+Several functions that were previously public (but marked as ^:no-doc) are now private.
+These functions were only exposed for testing purposes.
+
 Schematic now requires Clojure 1.10.1.
 
 [Closed Issues](https://github.com/walmartlabs/schematic/milestone/3?closed=1)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A more complete example is:
    (assoc this :started nil)))
 
 (def config
-  {:app {:sc/create-fn 'user/map->App
+  {:app {:sc/create-fn `map->App
          :sc/refs {:server :webserver}
          :sc/merge [{:to [:api-keys] :from [:api :keys]}]}
   
@@ -110,6 +110,9 @@ A more complete example is:
 Notice, in the above, that the Schematic keys (`:sc/create-fn`, etc.) have
 been removed, and the configuration for the `:app` component has been
 extended via `:sc/merge`.
+
+Of course, in a more realistic example, the configuration data would be read from 
+an EDN file, rather than hard-coded into the application.
 
 The following sections will cover aspects seen in the above example.
 
@@ -264,8 +267,9 @@ Two possible such scenarios are:
 each need a portion of the components at runtime, but not all of them.
 * At the REPL, it might be useful to get a particular component and start it, such as a database connection.
 
-In such cases, the `:component-ids` argument can be provided to `assemble-system`.
-The component-ids represent the top-level components which must be included in the final system.
+In such cases, the two argument version of `assemble-system` can be invoked, passing
+the list of component ids as the second parameter.
+There are the top-level components which must be included in the final system.
 Only these top-level components and all of their transitive dependencies will be included in
 the final system map.
 
@@ -291,6 +295,8 @@ Example (include single app):
 ;;  :db-conn {:host "localhost", :username "user", :password "secret"}}
 ```
 Notice that `:app-2` and `:customer-api` have not been included in the final system.
+
+This filtering of components occurs before components are properly instantiated (via the :sc/create-fn function).
 
 Example (development at the REPL):
 ```clojure

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/walmartlabs/schematic"
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.stuartsierra/component "0.3.2"]]
   :plugins [[lein-codox "0.10.3"]
             [test2junit "1.2.5"]]

--- a/src/com/walmartlabs/schematic.clj
+++ b/src/com/walmartlabs/schematic.clj
@@ -69,8 +69,7 @@
 
 (defn ^:no-doc associate-dependency-metadata
   "If v is an associative structure, finds any declared dependencies and associates appropriate
-   Component metadata. If it is not associative, the original value is returned.
-   Any pre-existing ::component/dependencies will be removed. "
+   Component metadata. If it is not associative, the original value is returned."
   [v]
   ;; Most every value in a schematic system is a map defining the component.
   ;; However, at the top level, there can be key/value pairs where the value is a scalar type;
@@ -83,11 +82,8 @@
                        init-fn (init-fn))]
       (if (instance? IObj component')
         (-> component'
-            ;; Sanity: clear any existing dependencies already present, though
-            ;; Such dependencies might exist in the metadata if a plain-Component constructor
-            ;; function is being re-used as a Schematic component init function.
-            ;; Schematic does not honor any dependency metadata applied by other means.
-            (vary-meta dissoc ::component/dependencies)
+            ;; Starting in 1.3, components (created by the create/fn) may have some dependencies which
+            ;; will be added to by Schematic.
             (component/using ref-map))
         component'))))
 


### PR DESCRIPTION
Changes:
- Clojure 1.10.1
- Catch exceptions when instantiating a component, report the component key and map
- Mark several ^:no-doc functions as ^:private instead